### PR TITLE
fix(ci): update PR checks to use pnpm run commands

### DIFF
--- a/.commits/fix-ci-update-pr-checks-to-use-pnpm-run-commands-2025-10-14.txt
+++ b/.commits/fix-ci-update-pr-checks-to-use-pnpm-run-commands-2025-10-14.txt
@@ -1,0 +1,7 @@
+fix(ci): update PR checks to use pnpm run commands
+
+Updates the `.github/workflows/pr-checks.yml` file to use `pnpm run lint` and
+`pnpm run test` instead of direct `turbo run` commands.
+
+This resolves the "turbo: command not found" error in the GitHub Actions
+environment, ensuring that CI checks for pull requests execute correctly.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run linting
-        run: turbo run lint
+        run: pnpm run lint
 
   test:
     needs: quality-gate
@@ -49,4 +49,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run tests
-        run: turbo run test
+        run: pnpm run test


### PR DESCRIPTION
Updates the `.github/workflows/pr-checks.yml` file to use `pnpm run lint` and `pnpm run test` instead of direct `turbo run` commands.

This resolves the "turbo: command not found" error in the GitHub Actions environment, ensuring that CI checks for pull requests execute correctly.